### PR TITLE
Migrate C++ wrappers from Zcoin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+    agent {
+        docker { image 'zcoinofficial/zcoin-builder:latest' }
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh 'git clean -d -f -f -q -x'
+                sh './autogen.sh'
+                sh './configure'
+                sh 'make dist'
+                sh 'mkdir -p dist'
+                sh 'tar -C dist --strip-components=1 -xzf libsecp256k1-*.tar.gz'
+                dir('dist') {
+                    sh './configure'
+                    sh 'make -j6'
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                dir('dist') {
+                    sh 'make check'
+                }
+            }
+        }
+    }
+}

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,12 @@ JNI_LIB =
 endif
 include_HEADERS = include/secp256k1.h
 include_HEADERS += include/secp256k1_preallocated.h
+include_HEADERS += include/secp256k1.hpp
+include_HEADERS += include/secp256k1_ecmult.hpp
+include_HEADERS += include/secp256k1_group.hpp
+include_HEADERS += include/secp256k1_scalar.hpp
 noinst_HEADERS =
+noinst_HEADERS += src/secp256k1.h
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h
 noinst_HEADERS += src/scalar_8x32.h
@@ -40,6 +45,11 @@ noinst_HEADERS += src/field_5x52.h
 noinst_HEADERS += src/field_5x52_impl.h
 noinst_HEADERS += src/field_5x52_int128_impl.h
 noinst_HEADERS += src/field_5x52_asm_impl.h
+noinst_HEADERS += src/cpp/ecmult.hpp
+noinst_HEADERS += src/cpp/group.hpp
+noinst_HEADERS += src/cpp/num.hpp
+noinst_HEADERS += src/cpp/scalar.hpp
+noinst_HEADERS += src/cpp/secp256k1.hpp
 noinst_HEADERS += src/java/org_bitcoin_NativeSecp256k1.h
 noinst_HEADERS += src/java/org_bitcoin_Secp256k1Context.h
 noinst_HEADERS += src/util.h
@@ -73,7 +83,7 @@ libsecp256k1_common_la_SOURCES = src/asm/field_10x26_arm.s
 endif
 endif
 
-libsecp256k1_la_SOURCES = src/secp256k1.c
+libsecp256k1_la_SOURCES = src/secp256k1.c src/cpp/secp256k1.cpp src/cpp/scalar.cpp src/cpp/group.cpp src/cpp/ecmult.cpp
 libsecp256k1_la_CPPFLAGS = -DSECP256K1_BUILD -I$(top_srcdir)/include -I$(top_srcdir)/src $(SECP_INCLUDES)
 libsecp256k1_la_LIBADD = $(JNI_LIB) $(SECP_LIBS) $(COMMON_LIB)
 
@@ -106,6 +116,16 @@ endif
 tests_LDADD = $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
 tests_LDFLAGS = -static
 TESTS += tests
+
+noinst_PROGRAMS += cpp_tests
+cpp_tests_SOURCES = src/cpp/tests.cpp
+cpp_tests_CPPFLAGS = -DSECP256K1_BUILD -I$(top_srcdir)/src -I$(top_srcdir)/include $(SECP_INCLUDES) $(SECP_TEST_INCLUDES)
+if !ENABLE_COVERAGE
+cpp_tests_CPPFLAGS += -DVERIFY
+endif
+cpp_tests_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
+cpp_tests_LDFLAGS = -static
+TESTS += cpp_tests
 endif
 
 if USE_EXHAUSTIVE_TESTS

--- a/build-aux/m4/m4_ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/m4_ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,951 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual ~Base() {}
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual ~Derived() override {}
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
+
+]])

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,9 @@ if test x"$ac_cv_prog_cc_c89" = x"no"; then
 fi
 AM_PROG_AS
 
+AC_PROG_CXX
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+
 case $host_os in
   *darwin*)
      if  test x$cross_compiling != xyes; then
@@ -115,9 +118,9 @@ AC_ARG_ENABLE(exhaustive_tests,
     [use_exhaustive_tests=yes])
 
 AC_ARG_ENABLE(endomorphism,
-    AS_HELP_STRING([--enable-endomorphism],[enable endomorphism [default=no]]),
+    AS_HELP_STRING([--disable-endomorphism],[disable endomorphism [default=yes]]),
     [use_endomorphism=$enableval],
-    [use_endomorphism=no])
+    [use_endomorphism=yes])
 
 AC_ARG_ENABLE(ecmult_static_precomputation,
     AS_HELP_STRING([--enable-ecmult-static-precomputation],[enable precomputed ecmult table for signing [default=auto]]),

--- a/include/secp256k1.hpp
+++ b/include/secp256k1.hpp
@@ -1,0 +1,17 @@
+#ifndef SECP256K1_HPP
+#define SECP256K1_HPP
+
+#include "secp256k1.h"
+
+#include <stddef.h>
+
+namespace secp256k1 {
+
+typedef void (*random_bytes_t) (unsigned char *buffer, size_t size);
+
+void initialize(secp256k1_context *ctx, random_bytes_t random);
+void terminate();
+
+} // namespace secp256k1
+
+#endif // SECP256K1_HPP

--- a/include/secp256k1_ecmult.hpp
+++ b/include/secp256k1_ecmult.hpp
@@ -1,0 +1,31 @@
+#ifndef SECP256K1_ECMULT_HPP
+#define SECP256K1_ECMULT_HPP
+
+#include "secp256k1_group.hpp"
+#include "secp256k1_scalar.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace secp_primitives {
+
+class MultiExponent {
+public:
+    struct Data;
+
+public:
+    MultiExponent(const std::vector<GroupElement>& generators, const std::vector<Scalar>& powers);
+    MultiExponent(const MultiExponent& other);
+    ~MultiExponent();
+
+    MultiExponent& operator=(const MultiExponent& other);
+
+    GroupElement get_multiple();
+
+private:
+    std::unique_ptr<Data> data;
+};
+
+}// namespace secp_primitives
+
+#endif // SECP256K1_ECMULT_HPP

--- a/include/secp256k1_group.hpp
+++ b/include/secp256k1_group.hpp
@@ -1,0 +1,100 @@
+#ifndef SECP256K1_GROUP_HPP
+#define SECP256K1_GROUP_HPP
+
+#include "secp256k1_scalar.hpp"
+
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <stddef.h>
+
+namespace secp_primitives {
+
+class GroupElement final {
+public:
+    static constexpr size_t serialize_size = 34;
+
+public:
+    struct Data;
+
+public:
+    GroupElement();
+    GroupElement(const char *x, const char *y, unsigned base = 10);
+    GroupElement(const Data& d);
+    GroupElement(const GroupElement& other);
+    ~GroupElement();
+
+    GroupElement& operator=(const GroupElement& other);
+
+    GroupElement operator*(const Scalar& scalar) const;
+    GroupElement& operator*=(const Scalar& scalar);
+    GroupElement operator+(const GroupElement& other) const;
+    GroupElement& operator+=(const GroupElement& other);
+
+    bool operator==(const GroupElement& other) const;
+    bool operator!=(const GroupElement& other) const;
+
+    const Data& get_data() const { return *data; }
+    size_t hash() const;
+    std::vector<unsigned char> getvch() const;
+    void sha256(unsigned char *result) const;
+
+    bool isMember() const;
+
+    GroupElement inverse() const;
+    void square();
+
+    GroupElement& set_base_g();
+    GroupElement& generate(const unsigned char *seed);
+    void randomize();
+
+    std::string GetHex() const;
+    std::string tostring(unsigned base = 10) const;
+
+    constexpr size_t memoryRequired() const { return serialize_size; }
+    unsigned char * serialize() const;
+    unsigned char * serialize(unsigned char *buffer) const;
+    const unsigned char * deserialize(const unsigned char *buffer);
+
+    unsigned GetSerializeSize(int nType = 0, int nVersion = 0) const { return memoryRequired(); }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        unsigned char buffer[memoryRequired()];
+        serialize(buffer);
+        s.write(buffer, sizeof(buffer));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        unsigned char buffer[memoryRequired()];
+        s.read(buffer, sizeof(buffer));
+        deserialize(buffer);
+    }
+
+private:
+    std::unique_ptr<Data> data;
+};
+
+} // namespace secp_primitives
+
+namespace std {
+
+template<typename Char, typename Traits>
+basic_ostream<Char, Traits> operator<<(basic_ostream<Char, Traits>& os, const secp_primitives::GroupElement& ge) {
+    return os << ge.tostring();
+}
+
+template<>
+struct hash<secp_primitives::GroupElement> {
+    size_t operator()(const secp_primitives::GroupElement& v) const {
+        return v.hash();
+    }
+};
+
+} // namespace std
+
+#endif // SECP256K1_GROUP_HPP

--- a/include/secp256k1_group.hpp
+++ b/include/secp256k1_group.hpp
@@ -54,7 +54,7 @@ public:
     std::string GetHex() const;
     std::string tostring(unsigned base = 10) const;
 
-    constexpr size_t memoryRequired() const { return serialize_size; }
+    size_t memoryRequired() const { return serialize_size; }
     unsigned char * serialize() const;
     unsigned char * serialize(unsigned char *buffer) const;
     const unsigned char * deserialize(const unsigned char *buffer);
@@ -63,14 +63,14 @@ public:
 
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
-        unsigned char buffer[memoryRequired()];
+        unsigned char buffer[serialize_size];
         serialize(buffer);
         s.write(buffer, sizeof(buffer));
     }
 
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
-        unsigned char buffer[memoryRequired()];
+        unsigned char buffer[serialize_size];
         s.read(buffer, sizeof(buffer));
         deserialize(buffer);
     }

--- a/include/secp256k1_group.hpp
+++ b/include/secp256k1_group.hpp
@@ -65,13 +65,13 @@ public:
     void Serialize(Stream& s, int nType, int nVersion) const {
         unsigned char buffer[serialize_size];
         serialize(buffer);
-        s.write(buffer, sizeof(buffer));
+        s.write(reinterpret_cast<char *>(buffer), sizeof(buffer));
     }
 
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
         unsigned char buffer[serialize_size];
-        s.read(buffer, sizeof(buffer));
+        s.read(reinterpret_cast<char *>(buffer), sizeof(buffer));
         deserialize(buffer);
     }
 

--- a/include/secp256k1_scalar.hpp
+++ b/include/secp256k1_scalar.hpp
@@ -1,0 +1,112 @@
+#ifndef SECP256K1_SCALAR_HPP
+#define SECP256K1_SCALAR_HPP
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <stddef.h>
+
+namespace secp_primitives {
+
+/**
+ * A C++ wrapper over scalar value.
+ **/
+class Scalar final {
+public:
+    struct Data;
+
+public:
+    Scalar();
+    explicit Scalar(unsigned value);
+    explicit Scalar(const unsigned char *bin);
+    Scalar(const Data& d);
+    Scalar(const Scalar& other);
+    ~Scalar();
+
+    Scalar& operator=(unsigned v);
+    Scalar& operator=(const unsigned char *bin);
+    Scalar& operator=(const Scalar& other);
+
+    Scalar operator*(const Scalar& other) const;
+    Scalar& operator*=(const Scalar& other);
+    Scalar operator+(const Scalar& other) const;
+    Scalar& operator+=(const Scalar& other);
+    Scalar operator-(const Scalar& other) const;
+    Scalar& operator-=(const Scalar& other);
+
+    bool operator==(const Scalar& other) const;
+    bool operator!=(const Scalar& other) const;
+
+    const Data& get_data() const { return *data; }
+    void get_bits(std::vector<bool>& bits) const;
+
+    bool isMember() const;
+
+    Scalar& mod_p();
+    Scalar inverse() const;
+    Scalar negate() const;
+    Scalar square() const;
+    Scalar exponent(unsigned exp) const;
+    Scalar exponent(const Scalar& exp) const;
+
+    void SetHex(const std::string& hex);
+    Scalar& generate(const unsigned char *bin);
+    Scalar& memberFromSeed(unsigned char *seed);
+    Scalar& randomize();
+
+    Scalar hash(const unsigned char *data, size_t len);
+
+    std::string GetHex() const;
+    std::string tostring(unsigned base = 10) const;
+
+    constexpr size_t memoryRequired() const { return 32; }
+    unsigned char * serialize(unsigned char *buffer) const;
+    const unsigned char * deserialize(const unsigned char *buffer);
+
+    constexpr unsigned GetSerializeSize(int nType = 0, int nVersion = 0) const {
+        return memoryRequired();
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        unsigned char buffer[memoryRequired()];
+        serialize(buffer);
+        s.write(reinterpret_cast<char *>(buffer), sizeof(buffer));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        unsigned char buffer[memoryRequired()];
+        s.read(reinterpret_cast<char *>(buffer), sizeof(buffer));
+        deserialize(buffer);
+    }
+
+private:
+    std::unique_ptr<Data> data;
+};
+
+} // namespace secp_primitives
+
+namespace std {
+
+template<typename Char, typename Traits>
+basic_ostream<Char, Traits>& operator<<(basic_ostream<Char, Traits>& os, const secp_primitives::Scalar& c) {
+    return os << c.tostring();
+}
+
+template<>
+struct hash<secp_primitives::Scalar> {
+    size_t operator()(const secp_primitives::Scalar& s) const {
+        array<unsigned char, 32> d;
+        s.serialize(d.data());
+        return hash<string>()(string(d.begin(), d.end()));
+    }
+};
+
+} // namespace std
+
+#endif // SECP256K1_SCALAR_HPP

--- a/include/secp256k1_scalar.hpp
+++ b/include/secp256k1_scalar.hpp
@@ -17,6 +17,9 @@ namespace secp_primitives {
  **/
 class Scalar final {
 public:
+    static constexpr size_t serialize_size = 32;
+
+public:
     struct Data;
 
 public:
@@ -63,24 +66,24 @@ public:
     std::string GetHex() const;
     std::string tostring(unsigned base = 10) const;
 
-    constexpr size_t memoryRequired() const { return 32; }
+    size_t memoryRequired() const { return serialize_size; }
     unsigned char * serialize(unsigned char *buffer) const;
     const unsigned char * deserialize(const unsigned char *buffer);
 
-    constexpr unsigned GetSerializeSize(int nType = 0, int nVersion = 0) const {
+    unsigned GetSerializeSize(int nType = 0, int nVersion = 0) const {
         return memoryRequired();
     }
 
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
-        unsigned char buffer[memoryRequired()];
+        unsigned char buffer[serialize_size];
         serialize(buffer);
         s.write(reinterpret_cast<char *>(buffer), sizeof(buffer));
     }
 
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
-        unsigned char buffer[memoryRequired()];
+        unsigned char buffer[serialize_size];
         s.read(reinterpret_cast<char *>(buffer), sizeof(buffer));
         deserialize(buffer);
     }

--- a/src/cpp/ecmult.cpp
+++ b/src/cpp/ecmult.cpp
@@ -1,0 +1,103 @@
+#include "ecmult.hpp"
+
+#include "group.hpp"
+#include "scalar.hpp"
+#include "secp256k1.hpp"
+
+#include "../scalar_impl.h"
+#include "../field_impl.h"
+#include "../group_impl.h"
+#include "../ecmult_impl.h"
+#include "../scratch_impl.h"
+#include "../util.h"
+
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include <stddef.h>
+
+namespace {
+
+void error_handler(const char *text, void *data) {
+    try {
+        reinterpret_cast<::std::string *>(data)->assign(text);
+    } catch (...) {
+        // this is called by C so we don't want C++ exception to go upper
+    }
+}
+
+int multi_handler(secp256k1_scalar *sc, secp256k1_ge *pt, size_t idx, void *data) {
+    auto d = reinterpret_cast<const ::secp_primitives::MultiExponent::Data *>(data);
+    auto ge = d->pt[idx]; // make a copy due to secp256k1_ge_set_gej need to modify it
+
+    *sc = d->sc[idx];
+    secp256k1_ge_set_gej(pt, &ge);
+
+    return 1;
+}
+
+} // unnamed namespace
+
+namespace secp_primitives {
+
+MultiExponent::MultiExponent(const std::vector<GroupElement>& generators, const std::vector<Scalar>& powers) : data(new Data()) {
+    if (generators.size() != powers.size()) {
+        throw std::invalid_argument("Number of generators and powers is mismatched");
+    }
+
+    data->sc.reserve(generators.size());
+    data->pt.reserve(generators.size());
+
+    for (size_t i = 0; i < generators.size(); i++) {
+        data->sc.push_back(powers[i].get_data().value);
+        data->pt.push_back(generators[i].get_data().value);
+    }
+}
+
+MultiExponent::MultiExponent(const MultiExponent& other) : data(new Data(*other.data)) {
+}
+
+MultiExponent::~MultiExponent() {
+    // don't remove this destructor otherwise it will inlined on the outside and cause linking error due to
+    // MultiExponent::Data is incomplete type
+}
+
+MultiExponent& MultiExponent::operator=(const MultiExponent& other) {
+    *data = *other.data;
+    return *this;
+}
+
+GroupElement MultiExponent::get_multiple() {
+    std::string err;
+    auto eh = secp256k1_callback{.fn = error_handler, .data = &err};
+    secp256k1_scratch *scratch;
+    GroupElement::Data r;
+    int status;
+
+    if (data->sc.size() > ECMULT_PIPPENGER_THRESHOLD) {
+        auto bucket_window = secp256k1_pippenger_bucket_window(data->sc.size());
+        auto scratch_size = secp256k1_pippenger_scratch_size(data->sc.size(), bucket_window);
+        scratch = secp256k1_scratch_create(&eh, scratch_size + PIPPENGER_SCRATCH_OBJECTS * ALIGNMENT);
+    } else {
+        auto scratch_size = secp256k1_strauss_scratch_size(data->sc.size());
+        scratch = secp256k1_scratch_create(&eh, scratch_size + STRAUSS_SCRATCH_OBJECTS * ALIGNMENT);
+    }
+
+    if (!scratch) {
+        // no need to grab the reason from err due to it is always out of memory, also bad_alloc does not accept the message
+        throw std::bad_alloc();
+    }
+
+    status = secp256k1_ecmult_multi_var(&eh, &secp256k1::default_context->ecmult_ctx, scratch, &r.value, nullptr, multi_handler, data.get(), data->sc.size());
+    secp256k1_scratch_destroy(&eh, scratch);
+
+    if (!status) {
+        // we can safely use err as the reason due to the only case secp256k1_scratch_destroy will fail is we pass invalid scratch
+        throw std::runtime_error(err);
+    }
+
+    return r;
+}
+
+} // namespace secp_primitives

--- a/src/cpp/ecmult.hpp
+++ b/src/cpp/ecmult.hpp
@@ -1,0 +1,22 @@
+#ifndef SECP256K1_CPP_ECMULT_HPP
+#define SECP256K1_CPP_ECMULT_HPP
+
+#include <secp256k1_ecmult.hpp>
+
+#include "secp256k1.hpp"
+
+#include "../group.h"
+#include "../scalar.h"
+
+#include <vector>
+
+namespace secp_primitives {
+
+struct MultiExponent::Data {
+    std::vector<secp256k1_scalar> sc;
+    std::vector<secp256k1_gej> pt;
+};
+
+} // namespace secp_primitives
+
+#endif // SECP256K1_CPP_ECMULT_HPP

--- a/src/cpp/group.cpp
+++ b/src/cpp/group.cpp
@@ -1,0 +1,378 @@
+#include "group.hpp"
+
+#include "num.hpp"
+#include "scalar.hpp"
+#include "secp256k1.hpp"
+
+#include "../group_impl.h"
+#include "../ecmult_impl.h"
+#include "../field_impl.h"
+#include "../hash_impl.h"
+#include "../num_impl.h"
+#include "../scalar_impl.h"
+
+#include <array>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <string.h>
+
+namespace {
+
+secp256k1_ge jacobian_to_affine(secp256k1_gej j) { // secp256k1_ge_set_gej need to write on j so need to pass by value
+    secp256k1_ge a;
+    secp256k1_ge_set_gej(&a, &j);
+    return a;
+}
+
+// Implements the algorithm from:
+//
+// Indifferentiable Hashing to Barreto-Naehrig Curves
+// Pierre-Alain Fouque and Mehdi Tibouchi
+// Latincrypt 2012
+void indifferent_hash(secp256k1_ge *ge, const secp256k1_fe *t) {
+    static const secp256k1_fe c = SECP256K1_FE_CONST(0x0a2d2ba9, 0x3507f1df, 0x233770c2, 0xa797962c, 0xc61f6d15, 0xda14ecd4, 0x7d8d27ae, 0x1cd5f852);
+    static const secp256k1_fe d = SECP256K1_FE_CONST(0x851695d4, 0x9a83f8ef, 0x919bb861, 0x53cbcb16, 0x630fb68a, 0xed0a766a, 0x3ec693d6, 0x8e6afa40);
+    static const secp256k1_fe b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 7);
+    static const secp256k1_fe b_plus_one = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 8);
+
+    secp256k1_fe wn, wd, x1n, x2n, x3n, x3d, jinv, tmp, x1, x2, x3, alphain, betain, gammain, y1, y2, y3;
+    int alphaquad, betaquad;
+
+    secp256k1_fe_mul(&wn, &c, t); /* mag 1 */
+    secp256k1_fe_sqr(&wd, t); /* mag 1 */
+    secp256k1_fe_add(&wd, &b_plus_one); /* mag 2 */
+    secp256k1_fe_mul(&tmp, t, &wn); /* mag 1 */
+    secp256k1_fe_negate(&tmp, &tmp, 1); /* mag 2 */
+    secp256k1_fe_mul(&x1n, &d, &wd); /* mag 1 */
+    secp256k1_fe_add(&x1n, &tmp); /* mag 3 */
+    x2n = x1n; /* mag 3 */
+    secp256k1_fe_add(&x2n, &wd); /* mag 5 */
+    secp256k1_fe_negate(&x2n, &x2n, 5); /* mag 6 */
+    secp256k1_fe_mul(&x3d, &c, t); /* mag 1 */
+    secp256k1_fe_sqr(&x3d, &x3d); /* mag 1 */
+    secp256k1_fe_sqr(&x3n, &wd); /* mag 1 */
+    secp256k1_fe_add(&x3n, &x3d); /* mag 2 */
+    secp256k1_fe_mul(&jinv, &x3d, &wd); /* mag 1 */
+    secp256k1_fe_inv(&jinv, &jinv); /* mag 1 */
+    secp256k1_fe_mul(&x1, &x1n, &x3d); /* mag 1 */
+    secp256k1_fe_mul(&x1, &x1, &jinv); /* mag 1 */
+    secp256k1_fe_mul(&x2, &x2n, &x3d); /* mag 1 */
+    secp256k1_fe_mul(&x2, &x2, &jinv); /* mag 1 */
+    secp256k1_fe_mul(&x3, &x3n, &wd); /* mag 1 */
+    secp256k1_fe_mul(&x3, &x3, &jinv); /* mag 1 */
+
+    secp256k1_fe_sqr(&alphain, &x1); /* mag 1 */
+    secp256k1_fe_mul(&alphain, &alphain, &x1); /* mag 1 */
+    secp256k1_fe_add(&alphain, &b); /* mag 2 */
+    secp256k1_fe_sqr(&betain, &x2); /* mag 1 */
+    secp256k1_fe_mul(&betain, &betain, &x2); /* mag 1 */
+    secp256k1_fe_add(&betain, &b); /* mag 2 */
+    secp256k1_fe_sqr(&gammain, &x3); /* mag 1 */
+    secp256k1_fe_mul(&gammain, &gammain, &x3); /* mag 1 */
+    secp256k1_fe_add(&gammain, &b); /* mag 2 */
+
+    alphaquad = secp256k1_fe_sqrt(&y1, &alphain);
+    betaquad = secp256k1_fe_sqrt(&y2, &betain);
+    secp256k1_fe_sqrt(&y3, &gammain);
+
+    secp256k1_fe_cmov(&x1, &x2, (!alphaquad) & betaquad);
+    secp256k1_fe_cmov(&y1, &y2, (!alphaquad) & betaquad);
+    secp256k1_fe_cmov(&x1, &x3, (!alphaquad) & !betaquad);
+    secp256k1_fe_cmov(&y1, &y3, (!alphaquad) & !betaquad);
+
+    secp256k1_ge_set_xy(ge, &x1, &y1);
+
+    /* The linked algorithm from the paper uses the Jacobi symbol of t to
+     * determine the Jacobi symbol of the produced y coordinate. Since the
+     * rest of the algorithm only uses t^2, we can safely use another criterion
+     * as long as negation of t results in negation of the y coordinate. Here
+     * we choose to use t's oddness, as it is faster to determine. */
+    secp256k1_fe_negate(&tmp, &ge->y, 1);
+    secp256k1_fe_cmov(&ge->y, &tmp, secp256k1_fe_is_odd(t));
+}
+
+} // unnamed namespace
+
+namespace secp_primitives {
+
+GroupElement::Data::Data() noexcept {
+    secp256k1_gej_clear(&value);
+    value.infinity = 1;
+}
+
+GroupElement::GroupElement() : data(new Data()) {
+}
+
+GroupElement::GroupElement(const char *x, const char *y, unsigned base) : GroupElement() {
+    secp256k1_ge v;
+
+    secp256k1_fe_set_b32(&v.x, secp256k1::parse_int(x, x + strlen(x), base).data());
+    secp256k1_fe_set_b32(&v.y, secp256k1::parse_int(y, y + strlen(y), base).data());
+    v.infinity = 0;
+
+    secp256k1_gej_set_ge(&data->value, &v);
+}
+
+GroupElement::GroupElement(const Data& d) : data(new Data(d)) {
+}
+
+GroupElement::GroupElement(const GroupElement& other) : data(new Data(*other.data)) {
+}
+
+GroupElement::~GroupElement() {
+    // don't remove this destructor otherwise it will inlined on the outside and cause linking error due to
+    // GroupElement::Data is incomplete type
+}
+
+GroupElement& GroupElement::operator=(const GroupElement &other) {
+    *data = *other.data;
+    return *this;
+}
+
+GroupElement GroupElement::operator*(const Scalar& scalar) const {
+    secp256k1_scalar ng;
+    Data r;
+
+    secp256k1_scalar_set_int(&ng, 0);
+    secp256k1_ecmult(&secp256k1::default_context->ecmult_ctx, &r.value, &data->value, &scalar.get_data().value, &ng);
+
+    return r;
+}
+
+GroupElement& GroupElement::operator*=(const Scalar& scalar) {
+    secp256k1_scalar ng;
+    secp256k1_gej r;
+
+    secp256k1_scalar_set_int(&ng, 0);
+    secp256k1_ecmult(&secp256k1::default_context->ecmult_ctx, &r, &data->value, &scalar.get_data().value, &ng);
+
+    data->value = r;
+
+    return *this;
+}
+
+GroupElement GroupElement::operator+(const GroupElement& other) const {
+    Data r;
+    secp256k1_gej_add_var(&r.value, &data->value, &other.data->value, nullptr);
+    return r;
+}
+
+GroupElement& GroupElement::operator+=(const GroupElement& other) {
+    secp256k1_gej r;
+
+    secp256k1_gej_add_var(&r, &data->value, &other.data->value, nullptr);
+    data->value = r;
+
+    return *this;
+}
+
+bool GroupElement::operator==(const  GroupElement& other) const {
+    if (data->value.infinity && other.data->value.infinity) {
+        return true;
+    }
+
+    if (data->value.infinity != other.data->value.infinity) {
+        return false;
+    }
+
+    auto a = jacobian_to_affine(data->value);
+    auto b = jacobian_to_affine(other.data->value);
+
+    if (!secp256k1_fe_equal(&a.x, &b.x) || !secp256k1_fe_equal(&a.y, &b.y)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool GroupElement::operator!=(const GroupElement& other) const {
+    return !(*this == other);
+}
+
+size_t GroupElement::hash() const {
+    auto v = jacobian_to_affine(data->value);
+    std::array<unsigned char, 32 * 2> coord;
+
+    if (v.infinity) {
+        coord.fill(0);
+    } else {
+        secp256k1_fe_get_b32(&coord[0], &v.x);
+        secp256k1_fe_get_b32(&coord[32], &v.y);
+    }
+
+    return std::hash<std::string>()(std::string(coord.begin(), coord.end()));
+}
+
+std::vector<unsigned char> GroupElement::getvch() const {
+    std::vector<unsigned char> result(memoryRequired(), 0);
+    serialize(result.data());
+    return result;
+}
+
+void GroupElement::sha256(unsigned char *result) const {
+    unsigned char buf[64];
+    secp256k1_rfc6979_hmac_sha256 sha256;
+
+    secp256k1_fe_get_b32(&buf[0], &data->value.x);
+    secp256k1_fe_get_b32(&buf[32], &data->value.y);
+
+    secp256k1_rfc6979_hmac_sha256_initialize(&sha256, buf, sizeof(buf));
+    secp256k1_rfc6979_hmac_sha256_generate(&sha256, result, 32);
+}
+
+bool GroupElement::isMember() const {
+    auto v = jacobian_to_affine(data->value);
+
+    if (secp256k1_ge_is_infinity(&v)) {
+        return true;
+    }
+
+    return secp256k1_ge_is_valid_var(&v);
+}
+
+GroupElement GroupElement::inverse() const {
+    Data r;
+    secp256k1_gej_neg(&r.value, &data->value);
+    return r;
+}
+
+void GroupElement::square() {
+    secp256k1_gej r;
+    secp256k1_gej_double_var(&r, &data->value, nullptr);
+    data->value = r;
+}
+
+GroupElement& GroupElement::set_base_g() {
+    secp256k1_gej_set_ge(&data->value, &secp256k1_ge_const_g);
+    return *this;
+}
+
+GroupElement& GroupElement::generate(const unsigned char *seed) {
+    static const unsigned char prefix1[16] = "1st generationn";
+    static const unsigned char prefix2[16] = "2nd generationn";
+
+    secp256k1_sha256 sha256;
+    unsigned char hash[32];
+    secp256k1_fe t = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 4);
+    secp256k1_ge add;
+    secp256k1_gej accum, tmp;
+    unsigned char gen[33];
+
+    int overflow;
+
+    secp256k1_sha256_initialize(&sha256);
+    secp256k1_sha256_write(&sha256, prefix1, sizeof(prefix1));
+    secp256k1_sha256_write(&sha256, seed, 32);
+    secp256k1_sha256_finalize(&sha256, hash);
+
+    secp256k1_fe_set_b32(&t, hash);
+    indifferent_hash(&add, &t);
+    secp256k1_gej_set_ge(&accum, &add);
+
+    secp256k1_sha256_initialize(&sha256);
+    secp256k1_sha256_write(&sha256, prefix2, sizeof(prefix2));
+    secp256k1_sha256_write(&sha256, seed, 32);
+    secp256k1_sha256_finalize(&sha256, hash);
+
+    secp256k1_fe_set_b32(&t, hash);
+    indifferent_hash(&add, &t);
+    secp256k1_gej_add_ge(&tmp, &accum, &add);
+    accum = tmp;
+
+    secp256k1_ge_set_gej(&add, &accum);
+    secp256k1_fe_normalize(&add.x);
+
+    secp256k1_fe_get_b32(gen + 1, &add.x);
+    gen[0] = 11 ^ secp256k1_fe_is_quad_var(&add.y);
+
+    // load group element from gen
+    secp256k1_fe fe;
+    secp256k1_ge ge;
+
+    secp256k1_fe_set_b32(&fe, gen + 1);
+    secp256k1_ge_set_xquad(&ge, &fe);
+
+    if (gen[0] & 1) {
+        secp256k1_ge v;
+        secp256k1_ge_neg(&v, &ge);
+        ge = v;
+    }
+
+    secp256k1_gej_set_ge(&data->value, &ge);
+
+    return *this;
+}
+
+void GroupElement::randomize() {
+    unsigned char seed[32];
+
+    do {
+        secp256k1::random_bytes(seed, sizeof(seed));
+        generate(seed);
+    } while (!isMember());
+}
+
+std::string GroupElement::GetHex() const {
+    return tostring(16);
+}
+
+std::string GroupElement::tostring(unsigned base) const {
+    auto v = jacobian_to_affine(data->value);
+
+    if (v.infinity) {
+        return "O";
+    }
+
+    std::stringstream s;
+    std::array<unsigned char, 32> x, y;
+
+    secp256k1_fe_get_b32(x.data(), &v.x);
+    secp256k1_fe_get_b32(y.data(), &v.y);
+
+    s << '(';
+    s << secp256k1::int_to_string(x.begin(), x.end(), base);
+    s << ',';
+    s << secp256k1::int_to_string(y.begin(), y.end(), base);
+    s << ')';
+
+    return s.str();
+}
+
+unsigned char * GroupElement::serialize() const {
+    std::unique_ptr<unsigned char[]> buf(new unsigned char [sizeof(secp256k1_fe) * 2]);
+
+    memcpy(&buf[0], data->value.x.n, sizeof(secp256k1_fe));
+    memcpy(&buf[sizeof(secp256k1_fe)], data->value.y.n, sizeof(secp256k1_fe));
+
+    return buf.release();
+}
+
+unsigned char * GroupElement::serialize(unsigned char *buffer) const {
+    auto v = jacobian_to_affine(data->value);
+
+    secp256k1_fe_normalize(&v.x);
+    secp256k1_fe_normalize(&v.y);
+
+    secp256k1_fe_get_b32(buffer, &v.x);
+    buffer[32] = secp256k1_fe_is_odd(&v.y);
+    buffer[33] = v.infinity;
+
+    return buffer + memoryRequired();
+}
+
+const unsigned char * GroupElement::deserialize(const unsigned char *buffer) {
+    secp256k1_fe x;
+    secp256k1_ge ge;
+
+    secp256k1_fe_set_b32(&x, buffer);
+    secp256k1_ge_set_xo_var(&ge, &x, buffer[32]);
+    ge.infinity = buffer[33];
+
+    secp256k1_gej_set_ge(&data->value, &ge);
+
+    return buffer + memoryRequired();
+}
+
+} // namespace secp_primitives

--- a/src/cpp/group.hpp
+++ b/src/cpp/group.hpp
@@ -1,0 +1,20 @@
+#ifndef SECP256K1_CPP_GROUP_HPP
+#define SECP256K1_CPP_GROUP_HPP
+
+#include <secp256k1_group.hpp>
+
+#include "secp256k1.hpp"
+
+#include "../group.h"
+
+namespace secp_primitives {
+
+struct GroupElement::Data {
+    secp256k1_gej value;
+
+    Data() noexcept;
+};
+
+} // namespace secp_primitives
+
+#endif // SECP256K1_CPP_GROUP_HPP

--- a/src/cpp/num.hpp
+++ b/src/cpp/num.hpp
@@ -1,0 +1,213 @@
+#ifndef SECP256K1_CPP_NUM_HPP
+#define SECP256K1_CPP_NUM_HPP
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <stddef.h>
+
+namespace secp256k1 {
+
+/**
+ * Do a negation on a range that represents an integer in a big-endian form.
+ *
+ * @return true if negation success without overflow; otherwise false.
+ **/
+template<typename Iterator>
+bool negate(Iterator first, Iterator last) {
+    // first, flip all bits
+    for (auto it = first; it != last; it++) {
+        *it ^= 0xFF;
+    }
+
+    // second, increase integer by 1
+    unsigned carry = 1;
+
+    for (auto it = last; it-- != first && carry > 0;) {
+        auto total = carry + *it;
+        *it = total % 256;
+        carry = total / 256;
+    }
+
+    // if there is remaining value to carry to the next byte that mean it is overflow
+    return carry ? false : true;
+}
+
+/**
+ * Convert an integer with each byte represent one digit in a binary form to another bases.
+ *
+ * @param from base of the number in each input digit, must be 2 to 256.
+ * @param to base of the number in  each output digit, must be 2 to 256.
+ *
+ * @return A binary represents an integer with each digit in the converted base in a binary form.
+ **/
+template<typename Iterator, typename Allocator = std::allocator<typename std::iterator_traits<Iterator>::value_type>>
+std::vector<typename std::iterator_traits<Iterator>::value_type, Allocator> convert_numeric_base(Iterator first, Iterator last, unsigned from, unsigned to) {
+    if (from < 2 || from > 256 || to < 2 || to > 256) {
+        throw std::invalid_argument("Invalid base number");
+    }
+
+    std::vector<typename std::iterator_traits<Iterator>::value_type, Allocator> result;
+
+    for (auto it = first; it != last; it++) {
+        unsigned carry = *it;
+
+        for (size_t i = 0; i < result.size() || carry != 0; i++) {
+            if (i == result.size()) {
+                result.push_back(0);
+            }
+
+            unsigned total = carry + from * result[i];
+            result[i] = total % to;
+            carry = total / to;
+        }
+    }
+
+    // the above operations produced a reversed order so we need to reverse it back
+    std::reverse(result.begin(), result.end());
+
+    return result;
+}
+
+/**
+ * Parse a string that represent an 256-bits integer.
+ *
+ * @return An 256-bits integer in big-endian form.
+ **/
+template<typename Iterator>
+std::array<unsigned char, 32> parse_int(Iterator first, Iterator last, unsigned base) {
+    if (first == last) {
+        throw std::invalid_argument("String is empty");
+    }
+
+    auto negative = (base != 16 && *first == '-');
+
+    if (negative) {
+        first++;
+    }
+
+    // get binary representation for each digit
+    std::vector<unsigned char> bin;
+
+    bin.reserve(std::distance(first, last));
+
+    for (auto it = first; it != last; it++) {
+        auto ch = *it;
+
+        switch (base) {
+        case 10:
+            if (ch >= '0' && ch <= '9') {
+                bin.push_back(ch - '0');
+            } else {
+                throw std::invalid_argument("String is not a valid base 10 integer");
+            }
+            break;
+        case 16:
+            if (ch >= '0' && ch <= '9') {
+                bin.push_back(ch - '0');
+            } else if (ch >= 'a' && ch <= 'f') {
+                bin.push_back(10 + (ch - 'a'));
+            } else if (ch >= 'A' && ch <= 'F') {
+                bin.push_back(10 + (ch - 'A'));
+            } else {
+                throw std::invalid_argument("String is not a valid base 10 integer");
+            }
+            break;
+        default:
+            throw std::invalid_argument("The specified base is not supported");
+        }
+    }
+
+    if (bin.empty()) {
+        throw std::invalid_argument("String is not a valid integer");
+    }
+
+    // convert the binary representation of the integer to the big-endian form
+    auto data = convert_numeric_base(bin.begin(), bin.end(), base, 256);
+
+    if (data.size() > 32) {
+        throw std::overflow_error("Value of the string is too large");
+    } else if (data.size() < 32) {
+        // prefixes with zeroes up to 256 bits
+        data.insert(data.begin(), 32 - data.size(), 0);
+    }
+
+    if (negative) {
+        negate(data.begin(), data.end());
+    }
+
+    // construct result
+    std::array<unsigned char, 32> result;
+
+    std::copy(data.begin(), data.end(), result.begin());
+
+    return result;
+}
+
+/**
+ * Convert an integer in a big-endian form into human-readable string.
+ **/
+template<typename Iterator>
+std::string int_to_string(Iterator first, Iterator last, unsigned base, bool sign = true) {
+    static const char digits_base10[] = "0123456789";
+    static const char digits_base16[] = "0123456789abcdef";
+    static const char *zero_base10 = "0";
+    static const char *zero_base16 = "0x00";
+
+    const char *digits, *zero;
+
+    switch (base) {
+    case 10:
+        digits = digits_base10;
+        zero = zero_base10;
+        break;
+    case 16:
+        digits = digits_base16;
+        zero = zero_base16;
+        break;
+    default:
+        throw std::invalid_argument("Invalid base");
+    }
+
+    // make a copy of value due to we need to modify it
+    std::vector<unsigned char> v;
+
+    v.reserve(std::distance(first, last));
+
+    std::copy(first, last, std::back_inserter(v));
+
+    if (v.empty()) {
+        return "";
+    }
+
+    // prefix with minus sign if it is negative
+    std::stringstream s;
+
+    if (sign && base != 16 && v[0] & 0x80) {
+        s << '-';
+        negate(v.begin(), v.end());
+    }
+
+    // get the binary representation of each digit
+    auto bin = convert_numeric_base(v.begin(), v.end(), 256, base);
+
+    if (bin.empty()) {
+        s << zero;
+    } else {
+        for (auto v : bin) {
+            s << digits[v];
+        }
+    }
+
+    return s.str();
+}
+
+} // namespace secp256k1
+
+#endif // SECP256K1_CPP_NUM_HPP

--- a/src/cpp/scalar.cpp
+++ b/src/cpp/scalar.cpp
@@ -1,0 +1,307 @@
+#include "scalar.hpp"
+
+#include "num.hpp"
+#include "secp256k1.hpp"
+
+#include "../hash_impl.h"
+#include "../scalar_impl.h"
+
+#include <array>
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdexcept>
+#include <stdlib.h>
+
+namespace secp_primitives {
+
+Scalar::Data::Data() noexcept {
+    secp256k1_scalar_clear(&value);
+}
+
+Scalar::Scalar() : data(new Data()) {
+}
+
+Scalar::Scalar(unsigned value) : Scalar() {
+    secp256k1_scalar_set_int(&data->value, value);
+}
+
+Scalar::Scalar(const unsigned char *bin) : Scalar() {
+    int overflow;
+
+    secp256k1_scalar_set_b32(&data->value, bin, &overflow);
+
+    if (overflow) {
+        throw std::overflow_error("The value is too large");
+    }
+}
+
+Scalar::Scalar(const Data& d) : data(new Data(d)) {
+}
+
+Scalar::Scalar(const Scalar& other) : data(new Data(*other.data)) {
+}
+
+Scalar::~Scalar() {
+    // don't remove this destructor otherwise it will inlined on the outside and cause linking error due to
+    // Scalar::Data is incomplete type
+}
+
+Scalar& Scalar::operator=(unsigned v) {
+    secp256k1_scalar_set_int(&data->value, v);
+    return *this;
+}
+
+Scalar& Scalar::operator=(const unsigned char *bin) {
+    secp256k1_scalar_set_b32(&data->value, bin, nullptr);
+    return *this;
+}
+
+Scalar& Scalar::operator=(const Scalar& other) {
+    *data = *other.data;
+    return *this;
+}
+
+Scalar Scalar::operator*(const Scalar& other) const {
+    Data d;
+    secp256k1_scalar_mul(&d.value, &data->value, &other.data->value);
+    return d;
+}
+
+Scalar& Scalar::operator*=(const Scalar& other) {
+    secp256k1_scalar r;
+
+    secp256k1_scalar_mul(&r, &data->value, &other.data->value);
+    data->value = r;
+
+    return *this;
+}
+
+Scalar Scalar::operator+(const Scalar& other) const {
+    Data d;
+    secp256k1_scalar_add(&d.value, &data->value, &other.data->value);
+    return d;
+}
+
+Scalar& Scalar::operator+=(const Scalar& other) {
+    secp256k1_scalar r;
+
+    secp256k1_scalar_add(&r, &data->value, &other.data->value);
+    data->value = r;
+
+    return *this;
+}
+
+Scalar Scalar::operator-(const Scalar& other) const {
+    secp256k1_scalar negated;
+    Data d;
+
+    secp256k1_scalar_negate(&negated, &other.data->value);
+    secp256k1_scalar_add(&d.value, &data->value, &negated);
+
+    return d;
+}
+
+Scalar& Scalar::operator-=(const Scalar& other) {
+    secp256k1_scalar negated, result;
+
+    secp256k1_scalar_negate(&negated, &other.data->value);
+    secp256k1_scalar_add(&result, &data->value, &negated);
+
+    data->value = result;
+
+    return *this;
+}
+
+bool Scalar::operator==(const Scalar& other) const {
+    return secp256k1_scalar_eq(&data->value, &other.data->value);
+}
+
+bool Scalar::operator!=(const Scalar& other) const {
+    return !(*this == other);
+}
+
+unsigned char * Scalar::serialize(unsigned char *buffer) const {
+    secp256k1_scalar_get_b32(buffer, &data->value);
+    return buffer + 32;
+}
+
+const unsigned char * Scalar::deserialize(const unsigned char *buffer) {
+    int overflow;
+
+    secp256k1_scalar_set_b32(&data->value, buffer, &overflow);
+
+    if (overflow) {
+        throw "Scalar: decoding overflowed";
+    }
+
+    return buffer + 32;
+}
+
+void Scalar::get_bits(std::vector<bool>& bits) const {
+    unsigned char bin[32];
+
+    secp256k1_scalar_get_b32(bin, &data->value);
+
+    for (auto b : bin) {
+        for (int j = 7; j >= 0; j--) {
+            bits.push_back((b >> j) & 1);
+        }
+    }
+}
+
+bool Scalar::isMember() const {
+    return *this == Scalar(*this).mod_p();
+}
+
+Scalar& Scalar::mod_p() {
+    secp256k1_scalar zero, result;
+
+    secp256k1_scalar_clear(&zero);
+    secp256k1_scalar_add(&result, &data->value, &zero);
+
+    data->value = result;
+
+    return *this;
+}
+
+Scalar Scalar::inverse() const {
+    Data d;
+    secp256k1_scalar_inverse(&d.value, &data->value);
+    return d;
+}
+
+Scalar Scalar::negate() const {
+    Data d;
+    secp256k1_scalar_negate(&d.value, &data->value);
+    return d;
+}
+
+Scalar Scalar::square() const {
+    Data d;
+    secp256k1_scalar_sqr(&d.value, &data->value);
+    return d;
+}
+
+Scalar Scalar::exponent(unsigned exp) const {
+    return exponent(Scalar(exp));
+}
+
+Scalar Scalar::exponent(const Scalar& exp) const {
+    auto value = data->value;
+    auto exp_ = exp.data->value;
+    Data result;
+
+    secp256k1_scalar_set_int(&result.value, 1);
+
+    while (!secp256k1_scalar_is_zero(&exp_)) {
+        secp256k1_scalar tmp;
+
+        if (!secp256k1_scalar_is_even(&exp_)) {
+            secp256k1_scalar_mul(&tmp, &result.value, &value);
+            result.value = tmp;
+        }
+
+        secp256k1_scalar_sqr(&tmp, &value);
+        value = tmp;
+
+        secp256k1_scalar_shr_int(&exp_, 1);
+    }
+
+    return result;
+}
+
+void Scalar::SetHex(const std::string& hex) {
+    if (hex.size() != 64) {
+        throw "Scalar: decoding invalid length";
+    }
+
+    unsigned char buffer[32];
+    int overflow;
+
+    for (size_t i = 0; i < 32; i++) {
+        auto b = hex.substr(i * 2, 2);
+
+        if (::isxdigit(b[0]) && ::isxdigit(b[1])) {
+            buffer[i] = strtol(b.c_str(), nullptr, 16);
+        } else {
+            throw "Scalar: decoding invalid hex";
+        }
+    }
+
+    secp256k1_scalar_set_b32(&data->value, buffer, &overflow);
+
+    if (overflow) {
+        throw "Scalar: decoding overflowed";
+    }
+}
+
+Scalar& Scalar::generate(const unsigned char *bin) {
+    secp256k1_scalar zero, result;
+
+    secp256k1_scalar_set_b32(&data->value, bin, nullptr);
+    secp256k1_scalar_set_int(&zero, 0);
+
+    secp256k1_scalar_add(&result, &data->value, &zero);
+    data->value = result;
+
+    return *this;
+}
+
+Scalar& Scalar::memberFromSeed(unsigned char *seed) {
+    // buffer -> object
+    deserialize(seed);
+
+    do {
+        // object -> buffer
+        serialize(seed);
+        // Hash from buffer, stores result in object
+        *this = hash(seed, 32);
+    } while (!isMember());
+
+    return *this;
+}
+
+Scalar& Scalar::randomize() {
+    unsigned char seed[32];
+
+    do {
+        secp256k1::random_bytes(seed, sizeof(seed));
+        generate(seed);
+    } while (!isMember());
+
+    return *this;
+}
+
+Scalar Scalar::hash(const unsigned char *data, size_t len) {
+    secp256k1_sha256 sha256;
+    unsigned char hash[32];
+    Data result;
+    int overflow;
+
+    secp256k1_sha256_initialize(&sha256);
+    secp256k1_sha256_write(&sha256, data, len);
+    secp256k1_sha256_finalize(&sha256, hash);
+
+    secp256k1_scalar_set_b32(&result.value, hash, &overflow);
+
+    if (overflow) {
+        throw "Scalar: hashing overflowed";
+    }
+
+    return Scalar(result).mod_p();
+}
+
+std::string Scalar::GetHex() const {
+    return tostring(16);
+}
+
+std::string Scalar::tostring(unsigned base) const {
+    std::array<unsigned char, 32> bin;
+
+    secp256k1_scalar_get_b32(bin.data(), &data->value);
+
+    return secp256k1::int_to_string(bin.begin(), bin.end(), base, false);
+}
+
+} // namespace secp_primitives

--- a/src/cpp/scalar.hpp
+++ b/src/cpp/scalar.hpp
@@ -1,0 +1,20 @@
+#ifndef SECP256K1_CPP_SCALAR_HPP
+#define SECP256K1_CPP_SCALAR_HPP
+
+#include <secp256k1_scalar.hpp>
+
+#include "secp256k1.hpp"
+
+#include "../scalar.h"
+
+namespace secp_primitives {
+
+struct Scalar::Data {
+    secp256k1_scalar value;
+
+    Data() noexcept;
+};
+
+} // namespace secp_primitives
+
+#endif // SECP256K1_CPP_SCALAR_HPP

--- a/src/cpp/secp256k1.cpp
+++ b/src/cpp/secp256k1.cpp
@@ -1,0 +1,18 @@
+#include "secp256k1.hpp"
+
+namespace secp256k1 {
+
+secp256k1_context *default_context;
+random_bytes_t random_bytes;
+
+void initialize(secp256k1_context *ctx, random_bytes_t random) {
+    default_context = ctx;
+    random_bytes = random;
+}
+
+void terminate() {
+    // for future use due to we already introduced initialize
+    // it will need to modify the caller site again if we introduce the terminate later
+}
+
+} // namespace secp256k1

--- a/src/cpp/secp256k1.hpp
+++ b/src/cpp/secp256k1.hpp
@@ -1,0 +1,15 @@
+#ifndef SECP256K1_CPP_SECP256K1_HPP
+#define SECP256K1_CPP_SECP256K1_HPP
+
+#include <secp256k1.hpp>
+
+#include "../secp256k1.h"
+
+namespace secp256k1 {
+
+extern secp256k1_context *default_context;
+extern random_bytes_t random_bytes;
+
+} // namespace secp256k1
+
+#endif // SECP256K1_CPP_SECP256K1_HPP

--- a/src/cpp/tests.cpp
+++ b/src/cpp/tests.cpp
@@ -1,0 +1,307 @@
+#ifdef HAVE_CONFIG_H
+#include "../libsecp256k1-config.h"
+#endif
+
+#ifndef ENABLE_OPENSSL_TESTS
+#error C++ tests required OpenSSL
+#endif
+
+#include <secp256k1.hpp>
+#include <secp256k1_ecmult.hpp>
+#include <secp256k1_group.hpp>
+#include <secp256k1_scalar.hpp>
+
+#include <openssl/rand.h>
+
+#include <exception>
+#include <iostream>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <stddef.h>
+#include <stdlib.h>
+
+namespace {
+
+struct assertion_failed : public std::runtime_error {
+    assertion_failed(const std::string& reason) : runtime_error("Assertion failed: " + reason) {}
+    assertion_failed(const std::string& expected, const std::string& actual) : assertion_failed("Expected = " + expected + ", Actual = " + actual) {}
+};
+
+template<typename Exception, typename Statement>
+void assert_throw(const std::string& err, Statement statement) {
+    try {
+        statement();
+        throw assertion_failed(err);
+    } catch (Exception&) {
+    }
+}
+
+void ecmult_multiple_multiplication() {
+    static const size_t sizes[] = {1, 4, 20, 57, 136, 235, 1260, 4420, 7880, 16050, 10, 100, 1000, 5000};
+
+    for (auto size : sizes) {
+        std::vector<secp_primitives::GroupElement> gens;
+        std::vector<secp_primitives::Scalar> scalars;
+        secp_primitives::GroupElement expect;
+
+        gens.reserve(size);
+        scalars.reserve(size);
+
+        for (size_t i = 0; i < size; i++) {
+            gens.emplace_back();
+            scalars.emplace_back();
+
+            gens[i].randomize();
+            scalars[i].randomize();
+
+            expect += gens[i] * scalars[i];
+        }
+
+        secp_primitives::MultiExponent multiexponent(gens, scalars);
+        auto actual = multiexponent.get_multiple();
+
+        if (actual != expect) {
+            throw assertion_failed(expect.tostring(), actual.tostring());
+        }
+    }
+}
+
+void ge_construct_default() {
+    secp_primitives::GroupElement v;
+    auto actual = v.tostring();
+
+    if (actual != "O") {
+        throw assertion_failed("O", actual);
+    }
+}
+
+void ge_construct_from_string() {
+    struct testcase {
+        unsigned base;
+        const char *x;
+        const char *y;
+    };
+
+    static const testcase cases[] = {
+        {
+            .base = 10,
+            .x = "9216064434961179932092223867844635691966339998754536116709681652691785432045",
+            .y = "33986433546870000256104618635743654523665060392313886665479090285075695067131"
+        },
+        {
+            .base = 10,
+            .x = "50204771751011461524623624559944050110546921468100198079190811223951215371253",
+            .y = "33986433546870000256104618635743654523665060392313886665479090285075695067131"
+        },
+        {
+            .base = 10,
+            .x = "7143275630583997983432964947790981761478339235433352888289260750805571589245",
+            .y = "11700086115751491157288596384709446578503357013980342842588483174733971680454"
+        },
+        {
+            .base = 10,
+            .x = "7143275630583997983432964947790981761478339235433352888289260750805571589245",
+            .y = "-11700086115751491157288596384709446578503357013980342842588483174733971680454"
+        },
+        {
+            .base = 16,
+            .x = "14601b8cdf761d4ed94554865ef0ef5c451e275f3dfc0a667fea04fa5a833bed",
+            .y = "4b23a3c385114c40cb4fbf02d1a52f731b4edf61c247372d038470eea90edffb"
+        },
+        {
+            .base = 16,
+            .x = "6efee4d1ba231acfee2391dc5ded838cee89235af14b8a4f494e4734cb1323f5",
+            .y = "4b23a3c385114c40cb4fbf02d1a52f731b4edf61c247372d038470eea90edffb"
+        },
+        {
+            .base = 16,
+            .x = "fcaf3630cd86c0b9dc6b122aeca20b065a14f861c291cd53a989f0e9fe1d47d",
+            .y = "19de0399d7578731a20abff9283e66117f8cc02be53c4cc86eb5ac3378c36cc6"
+        },
+        {
+            .base = 16,
+            .x = "fcaf3630cd86c0b9dc6b122aeca20b065a14f861c291cd53a989f0e9fe1d47d",
+            .y = "e621fc6628a878ce5df54006d7c199ee80733fd41ac3b337914a53cc873c933a"
+        }
+    };
+
+    for (auto& c : cases) {
+        secp_primitives::GroupElement v(c.x, c.y, c.base);
+        auto expect = std::string("(") + c.x + ',' + c.y + ')';
+        auto actual = v.tostring(c.base);
+
+        if (actual != expect) {
+            throw assertion_failed(expect, actual);
+        }
+    }
+}
+
+void ge_construct_from_other() {
+    secp_primitives::GroupElement v;
+
+    v.randomize();
+
+    secp_primitives::GroupElement c(v);
+
+    if (c != v) {
+        throw assertion_failed(v.tostring(), c.tostring());
+    }
+}
+
+void scalar_construct_default() {
+    secp_primitives::Scalar v;
+    auto actual = v.tostring();
+
+    if (actual != "0") {
+        throw assertion_failed("0", actual);
+    }
+}
+
+void scalar_construct_from_int() {
+    secp_primitives::Scalar v(50000);
+    auto actual = v.tostring();
+
+    if (actual != "50000") {
+        throw assertion_failed("50000", actual);
+    }
+}
+
+void scalar_construct_from_bin() {
+    static const unsigned char zero[32] = { 0 };
+    static const unsigned char one[32] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
+    static const unsigned char max_positive[32] = { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    static const unsigned char max_negative[32] = { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    static const unsigned char overflow[32] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+
+    std::string actual;
+
+    if ((actual = secp_primitives::Scalar(zero).tostring()) != "0") {
+        throw assertion_failed("0", actual);
+    }
+
+    if ((actual = secp_primitives::Scalar(one).tostring()) != "1") {
+        throw assertion_failed("1", actual);
+    }
+
+    if ((actual = secp_primitives::Scalar(max_positive).tostring()) != "57896044618658097711785492504343953926634992332820282019728792003956564819967") {
+        throw assertion_failed("57896044618658097711785492504343953926634992332820282019728792003956564819967", actual);
+    }
+
+    if ((actual = secp_primitives::Scalar(max_negative).tostring()) != "57896044618658097711785492504343953926634992332820282019728792003956564819968") {
+        throw assertion_failed("57896044618658097711785492504343953926634992332820282019728792003956564819968", actual);
+    }
+
+    assert_throw<std::overflow_error>("Not overflowed", [] () {
+        secp_primitives::Scalar v(overflow);
+    });
+}
+
+void scalar_construct_from_other() {
+    secp_primitives::Scalar v(99);
+    secp_primitives::Scalar c(v);
+
+    if (c != v) {
+        throw assertion_failed(v.tostring(), c.tostring());
+    }
+}
+
+void scalar_multiplication() {
+    secp_primitives::Scalar v(50000), m(2), r;
+    std::string actual;
+
+    r = v * m;
+    v *= m;
+    v *= m;
+
+    if ((actual = r.tostring()) != "100000") {
+        throw assertion_failed("100000", actual);
+    }
+
+    if ((actual = v.tostring()) != "200000") {
+        throw assertion_failed("200000", actual);
+    }
+}
+
+} // unnamed namespace
+
+int main(int argc, char *argv[]) {
+    std::unordered_set<std::string> selected;
+    secp256k1_context *ctx;
+    size_t total;
+    std::string current;
+
+    for (int i = 1; i < argc; i++) {
+        selected.insert(argv[i]);
+    }
+
+    // setup test environment
+    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    if (!ctx) {
+        std::cerr << "Failed to create secp256k1's context." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        secp256k1::initialize(ctx, [] (unsigned char *buf, size_t size) {
+            while (!RAND_bytes(buf, size));
+        });
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        secp256k1_context_destroy(ctx);
+        return EXIT_FAILURE;
+    }
+
+    // execute tests
+    struct testcase {
+        const char *name;
+        void (*func) ();
+    };
+
+    #define TESTCASE(func) { #func, func }
+
+    static const testcase cases[] = {
+        TESTCASE(ecmult_multiple_multiplication),
+        TESTCASE(ge_construct_default),
+        TESTCASE(ge_construct_from_string),
+        TESTCASE(ge_construct_from_other),
+        TESTCASE(scalar_construct_default),
+        TESTCASE(scalar_construct_from_int),
+        TESTCASE(scalar_construct_from_bin),
+        TESTCASE(scalar_construct_from_other),
+        TESTCASE(scalar_multiplication)
+    };
+
+    total = 0;
+
+    try {
+        for (auto& c : cases) {
+            if (!selected.empty() && !selected.count(c.name)) {
+                continue;
+            }
+
+            std::cout << "Running " << c.name << "..." << std::endl;
+
+            current = c.name;
+            c.func();
+
+            total++;
+        }
+    } catch (std::exception& e) {
+        std::cerr << '[' << current << "] " << e.what() << std::endl;
+        secp256k1::terminate();
+        secp256k1_context_destroy(ctx);
+        return EXIT_FAILURE;
+    }
+
+    secp256k1::terminate();
+    secp256k1_context_destroy(ctx);
+
+    std::cout << std::endl << "Total tests: " << total << '.' << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -20,7 +20,6 @@ typedef struct {
 #endif
 } secp256k1_ecmult_context;
 
-static const size_t SECP256K1_ECMULT_CONTEXT_PREALLOCATED_SIZE;
 static void secp256k1_ecmult_context_init(secp256k1_ecmult_context *ctx);
 static void secp256k1_ecmult_context_build(secp256k1_ecmult_context *ctx, void **prealloc);
 static void secp256k1_ecmult_context_finalize_memcpy(secp256k1_ecmult_context *dst, const secp256k1_ecmult_context *src);

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -35,7 +35,6 @@ typedef struct {
     secp256k1_gej initial;
 } secp256k1_ecmult_gen_context;
 
-static const size_t SECP256K1_ECMULT_GEN_CONTEXT_PREALLOCATED_SIZE;
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context* ctx);
 static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context* ctx, void **prealloc);
 static void secp256k1_ecmult_gen_context_finalize_memcpy(secp256k1_ecmult_gen_context *dst, const secp256k1_ecmult_gen_context* src);

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -20,6 +20,8 @@
 #include "hash_impl.h"
 #include "scratch_impl.h"
 
+#include "secp256k1.h"
+
 #define ARG_CHECK(cond) do { \
     if (EXPECT(!(cond), 0)) { \
         secp256k1_callback_call(&ctx->illegal_callback, #cond); \
@@ -59,13 +61,6 @@ static const secp256k1_callback default_illegal_callback = {
 static const secp256k1_callback default_error_callback = {
     secp256k1_default_error_callback_fn,
     NULL
-};
-
-struct secp256k1_context_struct {
-    secp256k1_ecmult_context ecmult_ctx;
-    secp256k1_ecmult_gen_context ecmult_gen_ctx;
-    secp256k1_callback illegal_callback;
-    secp256k1_callback error_callback;
 };
 
 static const secp256k1_context secp256k1_context_no_precomp_ = {

--- a/src/secp256k1.h
+++ b/src/secp256k1.h
@@ -1,6 +1,10 @@
 #ifndef SECP256K1_SECP256K1_H
 #define SECP256K1_SECP256K1_H
 
+#ifdef HAVE_CONFIG_H
+#include "libsecp256k1-config.h"
+#endif
+
 #include "ecmult.h"
 #include "ecmult_gen.h"
 #include "util.h"

--- a/src/secp256k1.h
+++ b/src/secp256k1.h
@@ -1,0 +1,15 @@
+#ifndef SECP256K1_SECP256K1_H
+#define SECP256K1_SECP256K1_H
+
+#include "ecmult.h"
+#include "ecmult_gen.h"
+#include "util.h"
+
+struct secp256k1_context_struct {
+    secp256k1_ecmult_context ecmult_ctx;
+    secp256k1_ecmult_gen_context ecmult_gen_ctx;
+    secp256k1_callback illegal_callback;
+    secp256k1_callback error_callback;
+};
+
+#endif /* SECP256K1_SECP256K1_H */


### PR DESCRIPTION
Need small modification at Zcoin side to use this version:

- Need to invoke `secp256k1::initialize` when starting and `secp256k1::terminate` when shutting down. Both functions is defined in `secp256k1.hpp`.
- File name to include (e.g. change `GroupElement.h` to `secp256k1_group.hpp`).
- `Scalar` no longer accept `uint64_t` in flavor of `unsigned int` to be matched with internal API. This should not need to do anything at Zcoin side.

Please add more tests after this PR was merged due to I need to switch back to ZTM next week.

Resolve https://github.com/zcoinofficial/zcoin/issues/751